### PR TITLE
[GV-29] Show error on login if student not enrolled. Add Redis Errors.

### DIFF
--- a/api/errors/redis/Base.js
+++ b/api/errors/redis/Base.js
@@ -2,8 +2,18 @@
  * Base error for redis errors.
  */
 export default class Base extends Error {
-    constructor(message) {
+    /**
+     * Creates a new base error.
+     * @constructor
+     * @param {string} message The base error message.
+     * @param {Error|null} [err=null] - the existing error that was thrown if any.
+     */
+    constructor(message, err) {
         super(message);
         this.service = 'Redis';
+        this.errorStack = [];
+        if (err?.errorStack) {
+            this.errorStack = [...err.errorStack, this];
+        }
     }
-} 
+}

--- a/api/errors/redis/KeyNotFound.js
+++ b/api/errors/redis/KeyNotFound.js
@@ -1,0 +1,20 @@
+import Base from './Base.js';
+
+/**
+ * Thrown when a key is not found in Redis.
+ */
+export default class KeyNotFoundError extends Base {
+    constructor(keyName, databaseIndex) {
+        if (typeof keyName !== 'string') {
+            throw new Error('keyName must be a string');
+        }
+
+        let smartMessage = "";
+        if (keyName) {
+            smartMessage += `Key "${keyName}" was not found in databaseIndex ${databaseIndex}`;
+        }
+        super(smartMessage);
+        this.name = 'KeyNotFoundError';
+        this.keyName = keyName;
+    }
+}

--- a/api/errors/redis/KeyNotFound.js
+++ b/api/errors/redis/KeyNotFound.js
@@ -4,17 +4,18 @@ import Base from './Base.js';
  * Thrown when a key is not found in Redis.
  */
 export default class KeyNotFoundError extends Base {
-    constructor(keyName, databaseIndex) {
-        if (typeof keyName !== 'string') {
-            throw new Error('keyName must be a string');
-        }
-
-        let smartMessage = "";
-        if (keyName) {
-            smartMessage += `Key "${keyName}" was not found in databaseIndex ${databaseIndex}`;
-        }
-        super(smartMessage);
+    /**
+     * Creates a new KeyNotFoundError.
+     * @constructor
+     * @param {string} message - The base error message.
+     * @param {string} keyName - The key that was queried.
+     * @param {int} databaseIndex - The index of the db that was queried.
+     * @param {Error|null} [err=null] - the existing error that was thrown if any.
+     */
+    constructor(message, keyName, databaseIndex, err=null) {
+        super(`${message}; key '${keyName}' not found in database with index ${databaseIndex}`, err);
         this.name = 'KeyNotFoundError';
         this.keyName = keyName;
+        this.databaseIndex = databaseIndex;
     }
 }

--- a/api/errors/redis/StudentNotEnrolled.js
+++ b/api/errors/redis/StudentNotEnrolled.js
@@ -8,9 +8,7 @@ export default class StudentNotEnrolledError extends Base {
         let smartMessage = message;
         
         // Append additional details if available
-        if (studentEmail && courseName) {
-            smartMessage += `; student "${studentEmail}" is not enrolled"`;
-        } else if (studentEmail) {
+        if (studentEmail) {
             smartMessage += `; student "${studentEmail}" is not enrolled`;
         }
 

--- a/api/errors/redis/StudentNotEnrolled.js
+++ b/api/errors/redis/StudentNotEnrolled.js
@@ -1,0 +1,22 @@
+import Base from './Base.js';
+
+/**
+ * Thrown when a student is not enrolled in a course or program.
+ */
+export default class StudentNotEnrolledError extends Base {
+    constructor(message, studentEmail) {
+        let smartMessage = message;
+        
+        // Append additional details if available
+        if (studentEmail && courseName) {
+            smartMessage += `; student "${studentEmail}" is not enrolled"`;
+        } else if (studentEmail) {
+            smartMessage += `; student "${studentEmail}" is not enrolled`;
+        }
+
+        // Call the Base class constructor with the smart message
+        super(smartMessage);
+        this.name = 'StudentNotEnrolledError';
+        this.studentEmail = studentEmail;
+    }
+}

--- a/api/errors/redis/StudentNotEnrolled.js
+++ b/api/errors/redis/StudentNotEnrolled.js
@@ -4,16 +4,15 @@ import Base from './Base.js';
  * Thrown when a student is not enrolled in a course or program.
  */
 export default class StudentNotEnrolledError extends Base {
-    constructor(message, studentEmail) {
-        let smartMessage = message;
-        
-        // Append additional details if available
-        if (studentEmail) {
-            smartMessage += `; student "${studentEmail}" is not enrolled`;
-        }
-
-        // Call the Base class constructor with the smart message
-        super(smartMessage);
+    /**
+     * Creates a new StudentNotEnrolledError.
+     * @constructor
+     * @param {string} message - The base error message.
+     * @param {string} studentEmail - The queried student email.
+     * @param {Error|null} err [err=null] - the existing error that was thrown if any.
+     */
+    constructor(message, studentEmail, err=null) {
+        super(`${message}; student '${studentEmail}' is not enrolled`, err);
         this.name = 'StudentNotEnrolledError';
         this.studentEmail = studentEmail;
     }

--- a/api/lib/authlib.mjs
+++ b/api/lib/authlib.mjs
@@ -55,14 +55,13 @@ export async function validateStudentMiddleware(req, _, next) {
     const { email } = req.params
 
     const authEmail = await getEmailFromAuth(req.headers['authorization']);
-    if (!isStudent(authEmail)) {
-        throw new AuthorizationError('not a registered student.');
+    const studentExists = await isStudent(authEmail);
+    if (!studentExists) {
+        throw new AuthorizationError('You are not a registered student.');
     }
-
     if (email && (authEmail !== email)) {
         throw new UnauthorizedAccessError('not permitted');
     }
-
     next();
 }
 

--- a/api/lib/redisHelper.mjs
+++ b/api/lib/redisHelper.mjs
@@ -39,7 +39,7 @@ export async function getEntry(key, databaseIndex = 0) {
         res = await client.get(key);
         // Check if the key exists, otherwise throw a custom error
         if (res === null) {
-            console.error(`Error while fetching key "${key}":`, error.message);
+            console.error('Error while fetching key "%s": %s', key, error.message);
             throw new NotFoundError(`Key "${key}" not found in database ${databaseIndex}`);
         }
     } finally {

--- a/api/lib/redisHelper.mjs
+++ b/api/lib/redisHelper.mjs
@@ -38,14 +38,14 @@ export async function getEntry(key, databaseIndex = 0) {
     try {
         const res = await client.get(key);
         if (res === null) {
-            const err = KeyNotFoundError("failed to get entry", key, databaseIndex);
+            const err = new KeyNotFoundError("failed to get entry", key, databaseIndex);
             console.error(err.message);
             throw err;
         }
+        return JSON.parse(res);
     } finally {
         await client.quit();
     }
-    return JSON.parse(res);
 }
 
 /**

--- a/api/lib/userlib.mjs
+++ b/api/lib/userlib.mjs
@@ -1,10 +1,9 @@
 import config from 'config';
 import { getStudent } from './redisHelper.mjs';
-import StudentNotEnrolledError from '../errors/redis/StudentNotEnrolled.js';
 
 /**
  * Checks if the specified user is an admin.
- * @param {string} email the email of the user to check.
+ * @param {string} email - the email of the user to check.
  * @returns {boolean} whether the user is an admin.
  */
 export function isAdmin(email) {
@@ -14,18 +13,20 @@ export function isAdmin(email) {
 
 /**
  * Checks if the specified user is a student.
- * @param {string} email the email of the user to check.
+ * @param {string} email - the email of the user to check.
  * @returns {boolean} whether the user is a student.
  */
 export async function isStudent(email) {
+    // TODO:at some point we should handle this more gracefully (check to see if the user exists instead of throwing an error).
     try {
         const student = await getStudent(email);
         return !!student;
-    } catch (error) {
-        if (error instanceof StudentNotEnrolledError) {
-            return false;
+    } catch (err) {
+        switch (typeof err) {
+            case 'StudentNotEnrolledError':
+                return false;
+            default:
+                throw err;
         }
-        // If it's another type of error, rethrow it to be handled elsewhere
-        throw error;
     }
 }

--- a/api/lib/userlib.mjs
+++ b/api/lib/userlib.mjs
@@ -1,6 +1,6 @@
 import config from 'config';
 import { getStudent } from './redisHelper.mjs';
-
+import  StudentNotFoundError from '../lib/HttpErrors/StudentNotFoundError.js';
 /**
  * Checks if the specified user is an admin.
  * @param {string} email the email of the user to check.
@@ -20,7 +20,11 @@ export async function isStudent(email) {
     try {
         const student = await getStudent(email);
         return !!student;
-    } catch (err) {
-        return false;
+    } catch (error) {
+        if (error instanceof StudentNotFoundError) {
+            return false;
+        }
+        // If it's another type of error, rethrow it to be handled elsewhere
+        throw error;
     }
 }

--- a/api/lib/userlib.mjs
+++ b/api/lib/userlib.mjs
@@ -1,6 +1,7 @@
 import config from 'config';
 import { getStudent } from './redisHelper.mjs';
-import  StudentNotFoundError from '../lib/HttpErrors/StudentNotFoundError.js';
+import StudentNotEnrolledError from '../errors/redis/StudentNotEnrolled.js';
+
 /**
  * Checks if the specified user is an admin.
  * @param {string} email the email of the user to check.
@@ -21,7 +22,7 @@ export async function isStudent(email) {
         const student = await getStudent(email);
         return !!student;
     } catch (error) {
-        if (error instanceof StudentNotFoundError) {
+        if (error instanceof StudentNotEnrolledError) {
             return false;
         }
         // If it's another type of error, rethrow it to be handled elsewhere

--- a/website/src/views/home.js
+++ b/website/src/views/home.js
@@ -7,6 +7,7 @@ import GradeGrid from '../components/GradeGrid';
 import Grid from '@mui/material/Unstable_Grid2';
 import ProjectionTable from '../components/ProjectionTable';
 import { StudentSelectionContext } from "../components/StudentSelectionWrapper";
+import { useNavigate } from 'react-router-dom';
 
 function Home() {
 
@@ -23,12 +24,23 @@ function Home() {
     const binsInfo = useFetch('/bins');
     const gradeInfo = useFetch(`students/${fetchEmail}/grades`);
     const projectionsInfo = useFetch(`/students/${fetchEmail}/projections`);
+    const navigate = useNavigate();
 
     useEffect(() => {
         if (binsInfo.data && localStorage.getItem('token')) {
             setBinsData(binsInfo.data.map(({ letter, points }) => [points, letter]));
         }
     }, [binsInfo.data]);
+
+
+    // Redirect to error page if any of the fetch requests return an error
+    useEffect(() => {
+        if (binsInfo.error || gradeInfo.error || projectionsInfo.error) {
+            const errorCode = binsInfo.error?.status || gradeInfo.error?.status || projectionsInfo.error?.status;
+            const errorText = binsInfo.error?.message || gradeInfo.error?.message || projectionsInfo.error?.message;
+            navigate('/serviceError', { state: { errorCode, errorText } });
+        }
+    }, [binsInfo.error, gradeInfo.error, projectionsInfo.error, navigate]);
 
     if (gradeInfo.loading || binsInfo.loading || projectionsInfo.loading) {
         return (<Loader />);

--- a/website/src/views/home.js
+++ b/website/src/views/home.js
@@ -7,7 +7,6 @@ import GradeGrid from '../components/GradeGrid';
 import Grid from '@mui/material/Unstable_Grid2';
 import ProjectionTable from '../components/ProjectionTable';
 import { StudentSelectionContext } from "../components/StudentSelectionWrapper";
-import { useNavigate } from 'react-router-dom';
 
 function Home() {
 
@@ -24,23 +23,12 @@ function Home() {
     const binsInfo = useFetch('/bins');
     const gradeInfo = useFetch(`students/${fetchEmail}/grades`);
     const projectionsInfo = useFetch(`/students/${fetchEmail}/projections`);
-    const navigate = useNavigate();
 
     useEffect(() => {
         if (binsInfo.data && localStorage.getItem('token')) {
             setBinsData(binsInfo.data.map(({ letter, points }) => [points, letter]));
         }
     }, [binsInfo.data]);
-
-
-    // Redirect to error page if any of the fetch requests return an error
-    useEffect(() => {
-        if (binsInfo.error || gradeInfo.error || projectionsInfo.error) {
-            const errorCode = binsInfo.error?.status || gradeInfo.error?.status || projectionsInfo.error?.status;
-            const errorText = binsInfo.error?.message || gradeInfo.error?.message || projectionsInfo.error?.message;
-            navigate('/serviceError', { state: { errorCode, errorText } });
-        }
-    }, [binsInfo.error, gradeInfo.error, projectionsInfo.error, navigate]);
 
     if (gradeInfo.loading || binsInfo.loading || projectionsInfo.loading) {
         return (<Loader />);

--- a/website/src/views/login.js
+++ b/website/src/views/login.js
@@ -29,9 +29,9 @@ export default function Login() {
         axios.get(`/api/v2/login`, {
             headers: { 'Authorization': token }
         }).then((loginRes) => {
-            console.log(loginRes);
+            console.log(`Login result: ${loginRes}`);
             if (!loginRes.data.status) {
-                setError('Account is not authorized.');
+                setError('You are not a registered student or admin.');
                 return;
             } else {
                 localStorage.setItem('token', token);

--- a/website/src/views/login.js
+++ b/website/src/views/login.js
@@ -29,7 +29,6 @@ export default function Login() {
         axios.get(`/api/v2/login`, {
             headers: { 'Authorization': token }
         }).then((loginRes) => {
-            console.log(`Login result: ${loginRes}`);
             if (!loginRes.data.status) {
                 setError('You are not a registered student or admin.');
                 return;

--- a/website/src/views/login.js
+++ b/website/src/views/login.js
@@ -30,7 +30,7 @@ export default function Login() {
             headers: { 'Authorization': token }
         }).then((loginRes) => {
             if (!loginRes.data.status) {
-                setError('You are not a registered student or admin.');
+                setError('You are not a registered student or admin.  Please contact course staff if you think this is a mistake.');
                 return;
             } else {
                 localStorage.setItem('token', token);


### PR DESCRIPTION
### Jira Ticket

<!-- Replace the field marked <ticket-id> with your ticket id -->
[Jira Ticket](https://dashbd.atlassian.net/browse/GV-29)

### Description

Fix bug where before everyone with a berkeley email could login. 

### Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Changes

When logged in, a 5xx error occurs since the student is not in the database. Now, we resolved a bug where if the student is not in the database (not enrolled in the course), the student cannot log in.
The key bug was forgetting to add `await` in front of `isStudent(authEmail)` so the function wasn't being called.

Also, this PR adds throwing errors in Redis if the key does not exist in the database (such as emails). Throw errors if the student is not enrolled.

### Testing

Tested by adding myself to admin and removing myself from admin config. Tested by adding and removing myself from the google sheets as a student and not as an admin.

### Checklist

- [ ] My branch name matches the format: `<ticket-id>/<brief-description-of-change>`
- [x] My PR name matches the format: `[<ticket-id>] <brief-description-of-change>`
- [x] I have added doc-comments to all new functions ([JSDoc](https://jsdoc.app/) for JS and [Docstrings](https://peps.python.org/pep-0257/) for Python)
- [x] I have reviewed all of my code
- [x] My code only contains major changes related to my ticket

### Screenshots/Video

![image](https://github.com/user-attachments/assets/95d156e1-fd09-4839-8deb-804f6a13f61d)

### Additional Notes

<!-- Any additional information or context relevant to this PR. -->
