### PR TITLE
[GV-48] Alphabetize student list for admin portal

### DIFF
--- a/website/src/components/NavBar.js
+++ b/website/src/components/NavBar.js
@@ -105,8 +105,11 @@ export default function ButtonAppBar() {
         if (isAdmin) {
             apiv2.get('/students').then((res) => {
                 if (mounted) {
-                    setStudents(res.data.students);
-                    setSelectedStudent(res.data.students[0][1]);
+                    const sortedStudents = res.data.students.sort((a, b) =>
+                        a[0].localeCompare(b[0])
+                    );
+                    setStudents(sortedStudents);
+                    setSelectedStudent(sortedStudents[0][1]);
                 }
             });
         }


### PR DESCRIPTION
### Jira Ticket

<!-- Replace the field marked <ticket-id> with your ticket id -->
[Jira Ticket](https://dashbd.atlassian.net/browse/GV-48)

### Description
The list of student on the instructor view of the dashboard needs to be alphabetized.
<!-- Briefly describe the feature being introduced. -->

### Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Changes
Alphabetizes students for instructors.
<!-- List the major changes made in this pull request. -->

### Testing
I tested manually using the Docker environment to verify the before and after effects of my changes. I believe this is sufficient to confirm the intended functionality, so I did not use automated testing strategies.
This was the list of students before: 
![image](https://github.com/user-attachments/assets/e9d4a693-0865-49bd-a3e8-97cef3278e27)

This was the list after, alphabetized. I want to note that student (abc, def) is selected first as well:
![image](https://github.com/user-attachments/assets/f18d7f33-387a-4366-a4a3-957e66e2b80c)

<!-- Describe how the feature has been tested, including both automated and manual testing strategies. -->

### Checklist

- [x] My branch name matches the format: `<ticket-id>/<brief-description-of-change>`
- [x] My PR name matches the format: `[<ticket-id>] <brief-description-of-change>`
- [x] I have added doc-comments to all new functions ([JSDoc](https://jsdoc.app/) for JS and [Docstrings](https://peps.python.org/pep-0257/) for Python)
- [x] I have reviewed all of my code
- [x] My code only contains major changes related to my ticket

### Screenshots/Video

<!-- Include screenshots or video demonstrating the new feature, if applicable. -->

### Additional Notes

<!-- Any additional information or context relevant to this PR. -->
