### PR TITLE
[GV-10] Update Grading Breakdown and Buckets spr25

### DIFF
--- a/website/src/views/buckets.js
+++ b/website/src/views/buckets.js
@@ -36,13 +36,12 @@ export default function Buckets() {
 
     const gradingRows = [
         createGradingRow('Quest', 25),
-        createGradingRow('Midterm', 80),
-        createGradingRow('Postterm', 100),
+        createGradingRow('Midterm', 50),
+        createGradingRow('Postterm',75),
         createGradingRow('Project 1: Wordle™-lite', 10),
         createGradingRow('Project 2: Spelling-Bee', 25),
         createGradingRow('Project 3: 2048', 35),
         createGradingRow('Project 4: Explore', 15),
-        createGradingRow('Project 5: Pyturis', 45),
         createGradingRow('Final Project', 60),
         createGradingRow('Labs', 80),
         createGradingRow('Attendance / Participation', 25)

--- a/website/src/views/buckets.js
+++ b/website/src/views/buckets.js
@@ -18,7 +18,7 @@ export default function Buckets() {
                 let tempBins = [];
                 for (let i = res.data.length - 1; i >= 0; i--) {
                     const grade = res.data[i]['letter'];
-                    const lower = (i !== 0) ? +res.data[i - 1]['points'] + 1 : 0;
+                    const lower = (i !== 0) ? +res.data[i - 1]['points'] : 0;
                     const range = `${lower}-${res.data[i]['points']}`;
                     tempBins.push({ grade, range });
                 }


### PR DESCRIPTION
### Linear Ticket

<!-- Replace the field marked <ticket-id> with your ticket id -->
[Linear Ticket](https://linear.app/afa-tooling/issue/GV-10/gv-10)

### Description

<!-- Briefly describe the feature being introduced. -->

The Grading Breakdown and Buckets for spr25 is updated.

### Type of Change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Changes

<!-- List the major changes made in this pull request. -->
The 'Grading Breakdown' is updated in buckets.js and is hardcoded. One project was removed and points of remaining assignments are updated. 'Buckets' is also updated by changing the associated and necessary values in the [CS10 | Sp24 | HAID sheet](https://docs.google.com/spreadsheets/d/1iX0ulEYbyYOy7Dehy3jGmSsWK4JAJA47Hvaa2cF7u1U/edit?gid=487103759#gid=487103759). The 'Buckets' logic was changed in buckets.js so that the bottom number in the range is the top number of the previous range - this is different from before. It used to be bottom number of range = top number of previous range + 1, but now is bottom number of range = top number of previous range as per the CS10 website (images attached below). 

### Testing

<!-- Describe how the feature has been tested, including both automated and manual testing strategies. -->
I ran the app locally using docker to see my changes implemented in real time. 

### Checklist

- [x] My branch name matches the format: `<ticket-id>/<brief-description-of-change>`
- [x] My PR name matches the format: `[<ticket-id>] <brief-description-of-change>`
- [x] I have added doc-comments to all new functions ([JSDoc](https://jsdoc.app/) for JS and [Docstrings](https://peps.python.org/pep-0257/) for Python)
- [x] I have reviewed all of my code
- [x] My code only contains major changes related to my ticket

### Screenshots/Video

<!-- Include screenshots or video demonstrating the new feature, if applicable. -->
<img width="1512" alt="Screenshot 2025-02-22 at 6 57 05 PM" src="https://github.com/user-attachments/assets/4740e7cd-925c-47ef-b5d7-6e6894ef8f95" />
<img width="1512" alt="Screenshot 2025-02-22 at 6 57 11 PM" src="https://github.com/user-attachments/assets/688f5435-dc2b-46f6-9388-3a9ff3ebabe4" />
<img width="1512" alt="Screenshot 2025-02-22 at 6 56 55 PM" src="https://github.com/user-attachments/assets/3be3a7ac-9ec9-4609-aefe-2df3dec022b1" />

### Additional Notes

<!-- Any additional information or context relevant to this PR. -->
